### PR TITLE
Fixed instructions for configuring php.ini.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sudo make install
 
 Finally you need to add
 ```
-extension=fann
+extension=fann.so
 ```
 to the php.ini
 


### PR DESCRIPTION
The change promoted fixes an error occuring on my Ubuntu after installing fann-php.
An error:
PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/lib/php5/20100525/fann' - /usr/lib/php5/20100525/fann: cannot open shared object file: No such file or directory in Unknown on line 0
