### PR TITLE
Added in readme the libtool failure fix during compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Then go to the created source directory and compile the extension. You need to h
 ```
 cd php-fann
 phpize
+aclocal && libtoolize --force && autoreconf
 ./configure --with-fann
 make
 sudo make install


### PR DESCRIPTION
Don't know why but compiling sometimes launch this kind of error:

```
...
libtool: Version mismatch error.  This is libtool 2.4.2 Debian-2.4.2-1.11, but the
libtool: definition of this LT_INIT comes from libtool 2.4.6.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.2 Debian-2.4.2-1.11
libtool: and run autoconf again.
...
```

Could be useful to someone else.