### PR TITLE
Missing "return true" at the end of the ann_callback.

### DIFF
--- a/tests/fann_set_callback_basic.phpt
+++ b/tests/fann_set_callback_basic.phpt
@@ -10,6 +10,7 @@ function ann_callback( $ann, $train_data, $max_epochs, $epochs_between_reports, 
 	var_dump($epochs_between_reports);
 	var_dump($desired_error);
 	var_dump($epochs);
+	return true;
 }
 
 $num_input = 2;


### PR DESCRIPTION
According to the [documentation](http://php.net/manual/en/function.fann-set-callback.php), the **return value** should be specified. Furthermore, if no return value is specified, **the callback will be called only once**, and not the number specified in _$epochs_between_reports_ (personally tested).