### PR TITLE
fix libraries link order

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -34,16 +34,16 @@ if test "$PHP_FANN" != "no"; then
 
   LIBNAME=fann
   LIBSYMBOL=fann_set_user_data
+  PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $FANN_DIR/$PHP_LIBDIR, FANN_SHARED_LIBADD)
+  PHP_ADD_LIBRARY(m)
 
   PHP_CHECK_LIBRARY($LIBNAME,$LIBSYMBOL,
   [
-    PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $FANN_DIR/$PHP_LIBDIR, FANN_SHARED_LIBADD)
-    AC_CHECK_LIB($LIBNAME,[fann_copy],[ AC_DEFINE(HAVE_FANN_2_2,1,[Fann library version 2.2]) ],[],[-lm])
+    AC_CHECK_LIB($LIBNAME,[fann_copy],[ AC_DEFINE(HAVE_FANN_2_2,1,[Fann library version 2.2]) ],[],[])
     AC_DEFINE(HAVE_FANN,1,[Fann library found])
   ],[
     AC_MSG_ERROR([wrong libfann version (you need at least version 2.1) or lib not found])
   ],[
-    -L$FANN_DIR/$PHP_LIBDIR -lm
   ])
 
   PHP_SUBST(FANN_SHARED_LIBADD)


### PR DESCRIPTION
When build using `-Wl,--as-needed`

```
checking for fann support... yes, shared
checking for libfann headers in default path... found in /usr
checking for fann_set_user_data in -lfann... no
configure: error: wrong libfann version (you need at least version 2.1) or lib not found

```

In config.log:

```
configure:4070: checking for fann_set_user_data in -lfann
configure:4095: cc -o conftest -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches  -m64 -mtune=generic  -W
l,-z,relro  -Wl,--as-needed  -Wl,-z,now   -lm conftest.c -lfann   >&5
/usr/lib/gcc/x86_64-redhat-linux/7/../../../../lib64/libfann.so: undefined reference to `sin'
/usr/lib/gcc/x86_64-redhat-linux/7/../../../../lib64/libfann.so: undefined reference to `exp'
/usr/lib/gcc/x86_64-redhat-linux/7/../../../../lib64/libfann.so: undefined reference to `sqrtf'
/usr/lib/gcc/x86_64-redhat-linux/7/../../../../lib64/libfann.so: undefined reference to `cos'
/usr/lib/gcc/x86_64-redhat-linux/7/../../../../lib64/libfann.so: undefined reference to `log'
/usr/lib/gcc/x86_64-redhat-linux/7/../../../../lib64/libfann.so: undefined reference to `pow'
collect2: error: ld returned 1 exit status

```

This simple PR ensure libm is loader after libfann, so allow to resolve missing symbol.

A better fix will be to use pkg-config output... but this one is also broken :(
```
$ pkg-config fann --libs
-lm -lfann 

```